### PR TITLE
no3 Hello World API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/example/HelloWorldApi/ExceptionHandlerAdvice.kt
+++ b/src/main/kotlin/com/example/HelloWorldApi/ExceptionHandlerAdvice.kt
@@ -1,0 +1,24 @@
+package com.example.HelloWorldApi
+
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.http.ResponseEntity
+
+@RestControllerAdvice
+class ExceptionHandlerAdvice {
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationExceptions(ex: MethodArgumentNotValidException): ResponseEntity<Map<String, Any>> {
+        val errors = ex.bindingResult.fieldErrors.map {
+            "${it.field}: ${it.defaultMessage}"
+        }
+
+        val responseBody = mapOf(
+            "reason" to "invalid parameter",
+            "detail" to errors
+        )
+
+        return ResponseEntity.badRequest().body(responseBody)
+    }
+}

--- a/src/main/kotlin/com/example/HelloWorldApi/HelloWorldController.kt
+++ b/src/main/kotlin/com/example/HelloWorldApi/HelloWorldController.kt
@@ -1,5 +1,6 @@
 package com.example.HelloWorldApi
 
+import jakarta.validation.Valid
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.springframework.web.bind.annotation.GetMapping
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 class HelloWorldController {
 
     @GetMapping("/hello")
-    fun hello(@RequestBody request: HelloWorldRequest): String {
+    fun hello(@Valid @RequestBody request: HelloWorldRequest): String {
         return Json.encodeToString(HelloWorldResponse.responseOf(request))
     }
 }

--- a/src/main/kotlin/com/example/HelloWorldApi/HelloWorldRequest.kt
+++ b/src/main/kotlin/com/example/HelloWorldApi/HelloWorldRequest.kt
@@ -1,8 +1,10 @@
 package com.example.HelloWorldApi
 
+import jakarta.validation.constraints.Size
 import kotlinx.serialization.Serializable
 
 @Serializable
 class HelloWorldRequest private constructor(
+    @field:Size(min = 3, max = 10, message = "nameは3文字以上10文字以内である必要があります")
     val name: String
 )


### PR DESCRIPTION
Validation	
nameに「3文字以上10文字以内」のValidationを設定する
ValidationExceptionが発生した際、HTTP Status 400でResponseをJsonで返却してください。
例: {"reason":"invalid parameter: detail: [[hello.name](http://hello.name/): 3 から 10 の間のサイズにしてください]"}

https://confluence.askul.co.jp/display/AskulEngineers/Cypher%3A+Spring+BootCamp